### PR TITLE
Improve class file identification

### DIFF
--- a/shell/generate-phpstorm-map.php
+++ b/shell/generate-phpstorm-map.php
@@ -248,7 +248,7 @@ class PhpStorm_Map_Generator extends Mage_Shell_Abstract
         /** @var $item SplFileInfo */
         foreach ($iterator as $item) {
             if ($item->isFile() &&
-                    substr($item->getBasename(), -4 === '.php')
+                    preg_match('/^[A-Za-z0-9\_]+\.php$/', $item->getBasename())
             ) {
                 if ($item->getBasename() == 'Abstract.php')
                     continue;


### PR DESCRIPTION
This PR to solve 2 problems:
- There is incorrect substr() parameter usage.
- Not all ".php" files to be considerate as class files. Magento also has installation scripts  (e.g. mysql4-install-0.0.1.php) and those should not be included as class files.
