### PR TITLE
Adds an instantiable check for all classes in the class map.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 PHPStorm Magento Mapper
 ========================
-This extension is for Magento Developers using PHPStorm. It generates a class map for autocompletion.
+This extension is for Magento developers using PhpStorm. It generates a class map for autocompletion.
 
 Facts
 -----
@@ -13,7 +13,7 @@ Facts
 
 Description
 -----------
-Build a class map for the new phpstorm feature introduced with the blog post
+Build a class map for the PhpStorm facorty support introduced with the blog posts.
 
  - [Support of static factories](http://blog.jetbrains.com/webide/2013/04/phpstorm-6-0-1-eap-build-129-177/)
  - [Support of non static factories](https://youtrack.jetbrains.com/issue/WI-27712)
@@ -41,11 +41,21 @@ Usage
 -----
 ```php shell/generate-phpstorm-map.php --file .phpstorm.meta.php```
 
-If no file is specified the classmap will be output to STDOUT
+If no file is specified the class map will be output to STDOUT
+
+Parameters
+-----
+
+| Option                    |    Default   | Description                                                                                                  |
+|---------------------------|:------------:|--------------------------------------------------------------------------------------------------------------|
+| ```--file```              | ```stdout``` | File location to save the output.                                                                            |
+| ```--instantiableCheck``` |   ```Off```  | Perform an additional instantiable check for each class. It its enabled the generate process will slow down. |
+| ```--phpExecutable```     |   ```php```  | Path to the php executable to start the instantiable check.                                                  |
+| ```--debug```             |   ```Off```  | Print debug output on ```stderr``` why classes gets excluded.                                                |
 
 Support
 -------
-If you have any issues with this extension, open an issue on GitHub (see URL above)
+If you have any issues with this extension, open an issue on GitHub (see URL above).
 
 Contribution
 ------------
@@ -54,9 +64,10 @@ Any contributions are highly appreciated. The best way to contribute code is to 
 
 Developer
 ---------
-Vinai Kopp
+* Vinai Kopp
 [http://www.netzarbeiter.com](http://www.netzarbeiter.com)
 [@VinaiKopp](https://twitter.com/VinaiKopp)
+* Erik Wohllebe
 
 Licence
 -------

--- a/README.md
+++ b/README.md
@@ -46,12 +46,12 @@ If no file is specified the class map will be output to STDOUT
 Parameters
 -----
 
-| Option                    |    Default   | Description                                                                                                  |
-|---------------------------|:------------:|--------------------------------------------------------------------------------------------------------------|
-| ```--file```              | ```stdout``` | File location to save the output.                                                                            |
-| ```--instantiableCheck``` |   ```Off```  | Perform an additional instantiable check for each class. It its enabled the generate process will slow down. |
-| ```--phpExecutable```     |   ```php```  | Path to the php executable to start the instantiable check.                                                  |
-| ```--debug```             |   ```Off```  | Print debug output on ```stderr``` why classes gets excluded.                                                |
+| Option                    |    Default   | Description                                                                                                   |
+|---------------------------|:------------:|---------------------------------------------------------------------------------------------------------------|
+| ```--file```              | ```stdout``` | File location to save the output.                                                                             |
+| ```--instantiableCheck``` |   ```Off```  | Perform an additional instantiable check for each class. If it's enabled the generate process will slow down. |
+| ```--phpExecutable```     |   ```php```  | Path to the php executable to start the instantiable check.                                                   |
+| ```--debug```             |   ```Off```  | Print debug output on ```stderr``` why classes gets excluded.                                                 |
 
 Support
 -------

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,10 @@
         {
             "name":"Vinai Kopp",
             "email":"vinai@netzarbeiter.com"
+        },
+        {
+            "name":"Erik Wohllebe",
+            "email":"Erik.Wohllebe@googlemail.com"
         }
     ],
     "require":{

--- a/shell/generate-phpstorm-map.php
+++ b/shell/generate-phpstorm-map.php
@@ -11,6 +11,13 @@ class PhpStorm_Map_Generator extends Mage_Shell_Abstract
      */
     protected $_config;
 
+    /**
+     * Holds the cached results of the instantiable check.
+     *
+     * @var array
+     */
+    protected $_instantiableClassCache = array();
+
     public function getConfig()
     {
         if (is_null($this->_config)) {
@@ -66,6 +73,15 @@ class PhpStorm_Map_Generator extends Mage_Shell_Abstract
             "\\Mage_Core_Block_Abstract::getHelper('')"       => $blocks,
         );
 
+        //Create an extension point to extend the map without override the file
+        $eventTransport      = new stdClass();
+        $eventTransport->map = $map;
+        Mage::dispatchEvent('phpstorm_map_generator_extend_map', array('transport' => $eventTransport));
+        $map = $eventTransport->map;
+
+        if ($this->isInstantiableCheckActive()) {
+            $map = $this->_cleanMap($map);
+        }
         $this->_writeMap($map);
     }
 
@@ -74,6 +90,7 @@ class PhpStorm_Map_Generator extends Mage_Shell_Abstract
      */
     public function getActiveModules()
     {
+        /* @var $config Mage_Core_Model_Config_Element */
         $modules = array();
         $config = $this->getConfig()->getNode('modules');
         foreach ($config->asArray() as $module => $info) {
@@ -263,15 +280,126 @@ class PhpStorm_Map_Generator extends Mage_Shell_Abstract
             if ($item->isFile() &&
                     preg_match('/^[A-Za-z0-9\_]+\.php$/', $item->getBasename())
             ) {
-                if ($item->getBasename() == 'Abstract.php')
-                    continue;
+                $file      = substr($item->getPathname(), strlen($dir) + 1); // Remove leading path
+                $file      = substr($file, 0, -4); // Remove .php
+                $className = str_replace(DS, '_', $file);
 
-                $file = substr($item->getPathname(), strlen($dir) + 1); // Remove leading path
-                $file = substr($file, 0, -4); // Remove .php
-                $classes[] = str_replace(DS, '_', $file);
+                if (!$this->isInstantiableCheckActive()
+                    && ($item->getBasename() == 'Abstract.php' || $item->getBasename() == 'Interface.php')
+                ) {
+                    $this->debug("Not instantiable: {$className}");
+                    continue;
+                }
+
+                $classes[] = $className;
             }
         }
         return $classes;
+    }
+
+    /**
+     * Remove all entries from the given class map that are not instantiable with a new operator.
+     *
+     * @param array $factoryMap
+     * @return array
+     */
+    protected function _cleanMap(array $factoryMap)
+    {
+        foreach ($factoryMap as $factory => $classMap) {
+            $classMapChunks = array_chunk($classMap, 10, true);
+            foreach ($classMapChunks as $classMapChunk) {
+                $invalidClasses = $this->_getNotInstantiableClasses($classMapChunk);
+                if ($invalidClasses) {
+                    foreach ($invalidClasses as $factoryName => $className) {
+                        unset($factoryMap[$factory][$factoryName]);
+                    }
+                }
+            }
+        }
+
+        return $factoryMap;
+    }
+
+    /**
+     * @param array $classMap
+     * @return array
+     */
+    protected function _getNotInstantiableClasses(array $classMap)
+    {
+        $invalidClasses = array();
+
+        //Remove classes that was already checked
+        foreach ($classMap as $factoryName => $className) {
+            if (isset($this->_instantiableClassCache[$className])) {
+                if (!$this->_instantiableClassCache[$className]) {
+                    $invalidClasses[$factoryName] = $className;
+                }
+                unset($classMap[$factoryName]);
+            }
+        }
+
+        //Check if all items was resolved form the cache
+        if (!$classMap) {
+            return $invalidClasses;
+        }
+
+        //Check if all classes are valid
+        if ($this->_isClassInstantiable($classMap, true)) {
+            foreach ($classMap as $className) {
+                $this->_instantiableClassCache[$className] = true;
+            }
+            return $invalidClasses;
+        }
+
+        //It not, we need to check all classes once by once
+        foreach ($classMap as $factoryName => $className) {
+            if ($this->_isClassInstantiable($className)) {
+                $this->_instantiableClassCache[$className] = true;
+            } else {
+                $invalidClasses[$factoryName]              = $className;
+                $this->_instantiableClassCache[$className] = false;
+            }
+        }
+
+        return $invalidClasses;
+    }
+
+    /**
+     * Perform an instantiable check for the given classes.
+     *
+     * The calculation the result for an single class creates a big overhead. Its better to call this method
+     * with an array of class names. If it fails for an chunk of class names you need to iterate over all
+     * elements of the chunk to detect all invalid class. Don't break on the first invalid  class because the
+     * chunk may contains multiple invalid classes.
+     *
+     * @param string|array $classNames
+     * @param bool         $skipLog
+     * @return bool
+     */
+    protected function _isClassInstantiable($classNames, $skipLog = false)
+    {
+        static $file = __DIR__ . DS . 'helper' . DS . 'instantiableTester.php';
+        if (!is_array($classNames)) {
+            $classNames = array($classNames);
+        }
+
+        $cmdClassNames = implode(' ', array_map('escapeshellarg', $classNames));
+        exec("{$this->getPhpExecutable()} -f={$file} {$cmdClassNames}", $execOutputLines);
+        if (isset($execOutputLines[0]) && 'Done' === $execOutputLines[0]) {
+            return true;
+        }
+
+        //Search the first non empty message
+        if (!$skipLog) {
+            foreach ($execOutputLines as $line) {
+                if (($line = trim($line))) {
+                    $this->debug("{$line}: " . implode(', ', $classNames));
+                    break;
+                }
+            }
+        }
+
+        return false;
     }
 
     protected function _writeMap(array $map)
@@ -314,10 +442,63 @@ namespace PHPSTORM_META {
         return <<<USAGE
 Usage:  php -f {$fileName} -- [options]
 
-  --file <map-file>  Defaults to stdout
-  help               This help
+  --file <map-file>      Defaults to <stdout>
+  --instantiableCheck    Activate instantiable check for every class
+  --phpExecutable <path> Define path to the php executable for the
+                         instantiable check, "php" by default
+  --debug                Enable debug output on <stderr>
+  help                   This help
 
 USAGE;
+    }
+
+    /**
+     * Log the given message to stderr if the debug flag is active.
+     *
+     * @param $message
+     * @return $this
+     */
+    public function debug($message)
+    {
+        if ($this->isDebugActive()) {
+            fwrite(STDERR, $message . PHP_EOL);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Return true if the instantiable check is active.
+     *
+     * @return bool
+     */
+    public function isInstantiableCheckActive()
+    {
+        return array_key_exists('instantiableCheck', $this->_args);
+    }
+
+    /**
+     * Return the path to the php executable.
+     *
+     * @return string
+     */
+    public function getPhpExecutable()
+    {
+        if (isset($this->_args['phpExecutable'])) {
+            return $this->_args['phpExecutable'];
+        }
+
+        return 'php';
+    }
+
+    /**
+     * Return true if the debug feature is enabled.
+     *
+     * @return bool
+     */
+    public function isDebugActive()
+    {
+        return array_key_exists('debug', $this->_args);
     }
 }
 

--- a/shell/generate-phpstorm-map.php
+++ b/shell/generate-phpstorm-map.php
@@ -249,10 +249,6 @@ class PhpStorm_Map_Generator extends Mage_Shell_Abstract
         return $classes;
     }
 
-    public function _lowercase()
-    {
-    }
-
     /**
      * @param $dir
      * @return array

--- a/shell/helper/instantiableTester.php
+++ b/shell/helper/instantiableTester.php
@@ -1,0 +1,79 @@
+<?php
+require_once dirname(dirname($argv[0])) . '/abstract.php';
+
+/**
+ * Class PhpStorm_Map_Generator_instantiableTester
+ */
+class PhpStorm_Map_Generator_instantiableTester extends Mage_Shell_Abstract
+{
+
+    /**
+     * Set this to false because we don't need a fully initialized magento. Otherwise the check need to long.
+     *
+     * @var bool
+     */
+    protected $_includeMage = false;
+
+    /**
+     * @inheritdoc
+     *
+     * This is a bug fix for setting up "_includeMage" to false. In this case the Mage class will not included.
+     * But in the parent constructor the factory class Mage_Core_Model_Factory gets initialized which occurs an
+     * error without setup the auto loader.
+     */
+    public function __construct()
+    {
+        require_once $this->_getRootPath() . 'app' . DIRECTORY_SEPARATOR . 'Mage.php';
+        parent::__construct();
+
+        //Display errors to show warnings and strict notices if the error level strict or notice is set
+        ini_set('display_errors', 1);
+    }
+
+    /**
+     * Check if all classes given by the cli are instantiable.
+     */
+    public function run()
+    {
+        $classNames = array_keys($this->_args);
+
+        //No classes given
+        if (!$classNames) {
+            exit(1);
+        }
+
+        //Perform single checks for the classes
+        foreach ($classNames as $className) {
+            $reflectionClass = new ReflectionClass($className);
+
+            //Is an interface?
+            if ($reflectionClass->isInterface()) {
+                echo "Interface";
+                exit(1);
+            }
+
+            //Is an abstract class?
+            if ($reflectionClass->isAbstract()) {
+                echo "Abstract";
+                exit(1);
+            }
+
+            //Is a trait?
+            if ($reflectionClass->isTrait()) {
+                echo "Trait";
+                exit(1);
+            }
+
+            //Can create the class with new?
+            if (!$reflectionClass->isInstantiable()) {
+                echo "Not instantiable";
+                exit(1);
+            }
+        }
+
+        echo 'Done';
+    }
+}
+
+$classCheck = new PhpStorm_Map_Generator_instantiableTester();
+$classCheck->run();


### PR DESCRIPTION
The main goal of this change is to remove all invalid class form the class map that are not able to return by a factory. This means interfaces, abstract classes, traits, classes with private constructor, classes with invalid class name and broken classes that can't define. To use the additional check the cli parameter
`--instantiableCheck` should use.
With the new debug flag (`--debug`), it is possible to see, why a class gets excluded from the class map.
It also possible to extend the class map without changing the code by using the event `phpstorm_map_generator_extend_map`.
