### PR TITLE
Update generate-phpstorm-map.php

### DIFF
--- a/shell/generate-phpstorm-map.php
+++ b/shell/generate-phpstorm-map.php
@@ -378,7 +378,7 @@ class PhpStorm_Map_Generator extends Mage_Shell_Abstract
      */
     protected function _isClassInstantiable($classNames, $skipLog = false)
     {
-        static $file = __DIR__ . DS . 'helper' . DS . 'instantiableTester.php';
+        $file = __DIR__ . DS . 'helper' . DS . 'instantiableTester.php';
         if (!is_array($classNames)) {
             $classNames = array($classNames);
         }


### PR DESCRIPTION
Fixes the `PHP Parse error:  syntax error, unexpected '.', expecting ',' or ';' in ...generate-phpstorm-map.php on line 381` problem on php 5.5
